### PR TITLE
$isSync constant no longer used- throws error

### DIFF
--- a/lib/orvfms/setup_page.php
+++ b/lib/orvfms/setup_page.php
@@ -78,7 +78,7 @@ function displaySetupPage($mac,&$s20Table,$myUrl){
     $serverDst = $dev['serverDst']; 
     $isSyncTZ = ($serverDst == $dst) && ($tz == $serverTz);
     $isSyncCK = (abs($serverTime - $time) < 5);
-    $isSync = isSyncTZ && $isSyncCK;
+    //$isSync = isSyncTZ && $isSyncCK; 
     if(!$isSyncCK){
         echo '<div style="color:red">Warning: clock seems out of sync!<p></div>';
     }


### PR DESCRIPTION
Clock and TZ are checked using $isSyncCK and $isSyncTZ.

$isSync is no longer checked or used following the update to the time synchronisation code but in PHP>7.2 it causes a runtime error in relation to it being an undefined constant.

https://stackoverflow.com/questions/48236765/undefined-constant-error-in-php-7-2